### PR TITLE
Adding pageProps

### DIFF
--- a/components/transition/index.js
+++ b/components/transition/index.js
@@ -1,6 +1,6 @@
-import { useRef, useState, useEffect, cloneElement, Fragment } from 'react'
+import { useRef, useState, useEffect, Fragment } from 'react'
 
-function Transition({ Component }) {
+function Transition({ Component, pageProps }) {
   const current = useRef()
   const next = useRef()
   const height = useRef()
@@ -9,10 +9,15 @@ function Transition({ Component }) {
   const [lifecycle, setLifecycle] = useState('starting')
 
   useEffect(() => {
+    Component.pageProps = pageProps
+  }, [])
+
+  useEffect(() => {
     if (!Component) return
     if (components[0].render.displayName === Component.render.displayName)
       return
     setComponents((data) => [data[0], Component])
+    Component.pageProps = pageProps
   }, [Component])
 
   useEffect(() => {
@@ -84,13 +89,13 @@ function Transition({ Component }) {
         {components.map((Page, id) => {
           return (
             Page !== null && (
-              <Fragment key={Page.render.displayName}>
+              <Fragment key={Page.render ? Page.render.displayName : Page.displayName}>
                 <Page
                   ref={(node) =>
                     id === 0 ? (current.current = node) : (next.current = node)
                   }
                   style={getPosition(id)}
-                  {...Page.props}
+                  {...Page.pageProps}
                 />
               </Fragment>
             )

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,7 +4,7 @@ import Transition from 'components/transition'
 
 import '../styles/base.scss'
 
-function App({ Component }) {
+function App({ Component, pageProps }) {
   useFoucFix()
 
   return (
@@ -15,7 +15,7 @@ function App({ Component }) {
         <meta name="description" content="" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <Transition Component={Component} />
+      <Transition Component={Component} pageProps={pageProps} />
     </>
   )
 }


### PR DESCRIPTION
Adding pageProps support to the `<Transition>` component.
Useful to fetch data using `getStaticProps` or `getServerSideProps` and pass it to the pages.

Extra: 
Also fixed a build error on the `<Transition>` component where Page.render is undefined for the 404 and 500 pages.
Changed this:
`<Fragment key={ Page.render.displayName}>`
into this:
`<Fragment key={Page.render ? Page.render.displayName : Page.displayName}>`